### PR TITLE
delete: devIndicatorsを非表示#8

### DIFF
--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  devIndicators: false
 };
 
 export default nextConfig;


### PR DESCRIPTION
Next.js15から追加されたdevIndicatorsを非表示にした